### PR TITLE
arch: update expact conanfiles_rtc

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -3,7 +3,7 @@ from conans import ConanFile
 
 class ExpatConan(ConanFile):
     name = "expat"
-    version = "2.6.2"
+    version = "2.6.3"
     url = "https://github.com/Esri/libexpat"
     license = "https://github.com/Esri/libexpat/blob/master/expat/COPYING"
     description = "Expat is a stream-oriented XML parser."


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/SoftwareSecurity/issues/43
- https://github.com/libexpat/libexpat/issues/887
- follow on from https://github.com/Esri/libexpat/pull/42

This PR adds updates the version number for libexpat in conanfiles_rtc.py to 2.6.3.
